### PR TITLE
added templates for the aws cloudwatch logs config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 logs/
 vendor/
 config/config.yml
+config/cloudwatchLogs/awscli.conf
+config/cloudwatchLogs/awslogs.conf
 build/
 kiln.tar.gz

--- a/cf-template/kiln.template
+++ b/cf-template/kiln.template
@@ -335,7 +335,7 @@
                 "#!/bin/bash -xe\n",
 
                 "yum update -y\n",
-                "yum install -y git php55-cli\n",
+                "yum install -y git php55-cli awslogs\n",
 
                 "wget https://dl.bintray.com/mitchellh/packer/packer_0.8.2_linux_amd64.zip\n",
                 "unzip packer_0.8.2_linux_amd64.zip -d /opt/packer\n",
@@ -363,6 +363,14 @@
                 " --buildRequestQueue ",
                 { "Ref": "KilnBuildRequestQueue"},
                 "\n",
+
+                "mv /etc/awslogs/awslogs.conf /etc/awslogs/awslogs.conf.stock\n",
+                "mv /etc/awslogs/awscli.conf /etc/awslogs/awscli.conf.stock\n",
+                "mkdir -p /var/awslogs/state\n",
+                "mv /home/ec2-user/kiln/config/cloudwatchLogs/awscli.conf /etc/awslogs/awscli.conf\n",
+                "mv /home/ec2-user/kiln/config/cloudwatchLogs/awslogs.conf /etc/awslogs/awslogs.conf\n",
+                "service awslogs start\n",
+                "chkconfig awslogs on\n",
 
                 "chown -R ec2-user:ec2-user /home/ec2-user/kiln\n"
 

--- a/config/cloudwatchLogs/awscli.dist.conf
+++ b/config/cloudwatchLogs/awscli.dist.conf
@@ -1,0 +1,4 @@
+[plugins]
+cwlogs = cwlogs
+[default]
+region = {{aws-region}}

--- a/config/cloudwatchLogs/awslogs.dist.conf
+++ b/config/cloudwatchLogs/awslogs.dist.conf
@@ -1,0 +1,24 @@
+[general]
+state_file = /var/awslogs/state/agent-state
+
+[/var/log/messages]
+## Path of log file for the agent to monitor and upload.
+file = /home/ec2-user/kiln/logs/app/*.log
+
+## A batch is buffered for buffer-duration amount of time or 32KB of log events.
+## Defaults to 5000 ms and its minimum value is 5000 ms.
+buffer_duration = 5000
+
+# Use 'end_of_file' to start reading from the end of the file.
+# Use 'start_of_file' to start reading from the beginning of the file.
+initial_position = start_of_file
+
+## Name of the destination log group.
+log_group_name = /kiln/logs/app
+
+## Name of the destination log stream. You may use {hostname} to use target machine's hostname.
+log_stream_name = {instance_id}
+
+## Format specifier for timestamp parsing
+## ex: 2015-08-03 19:32:02.592545
+datetime_format = %Y-%m-%d %H:%M:%S.%f

--- a/init-config.php
+++ b/init-config.php
@@ -37,6 +37,10 @@ $cliDefinitions = [
     ]
 ];
 
+/**
+ * @param array $cliDefinitions
+ * @return string
+ */
 function getUsage($cliDefinitions)
 {
     $usage = "Usage:\n";
@@ -47,6 +51,12 @@ function getUsage($cliDefinitions)
     return $usage;
 }
 
+/**
+ * @param string $argName
+ * @param array $cliArgs
+ * @param array $cliDefinitions
+ * @return string
+ */
 function getCliArg($argName, $cliArgs, $cliDefinitions)
 {
     $argValue = getCliArgValue($cliArgs, "--{$argName}");
@@ -58,16 +68,36 @@ function getCliArg($argName, $cliArgs, $cliDefinitions)
     return $argValue;
 }
 
+/**
+ * @param array $cliDefinitions
+ * @param array $argv
+ * @param \Io\Samk\AmiBuilder\Utils\Config $config
+ */
 function processCli($cliDefinitions, $argv, $config)
 {
     foreach($cliDefinitions as $cliArgName => $cliArgDef) {
         list($sectionKey, $itemKey) = explode('.', $cliArgDef['configKeyPath']);
         $config->setSectionValue($sectionKey, $itemKey, getCliArg($cliArgName, $argv, $cliDefinitions));
     }
+}
 
+/**
+ * @param string $awsRegion
+ */
+function createCloudWatchLogsConfigs($awsRegion) {
+    $cloudWatchLogsConfDir = __DIR__ . '/config/cloudwatchLogs';
+    $awsCliConfContent = file_get_contents("{$cloudWatchLogsConfDir}/awscli.dist.conf");
+    $awsCliConfContent = str_replace('{{aws-region}}', $awsRegion,$awsCliConfContent);
+    file_put_contents("{$cloudWatchLogsConfDir}/awscli.conf", $awsCliConfContent);
+    // nothing to replace in this file
+    copy("{$cloudWatchLogsConfDir}/awslogs.dist.conf", "{$cloudWatchLogsConfDir}/awslogs.conf");
 }
 
 $logger = getAppLogger(getExecutionUuid());
 $config = getConfig(__DIR__ . '/config/config.dist.yml', $logger);
 processCli($cliDefinitions, $argv, $config);
 $config->dumpYamlTo(__DIR__ . "/config/config.yml");
+
+// write the AWS CloudWatch Logs configs to ./config/cloudwatchLogs
+// the deploy script will mv them to the proper place on the machine filesystem
+createCloudWatchLogsConfigs(getCliArg('awsRegion', $argv, $cliDefinitions));


### PR DESCRIPTION
- init-config now creates to production files form the templates
- cf-template mv's the files into place on the build maching and
  completes the awslogs install
fixes #6