### PR TITLE
unique name for the audit trail S3 bucket

### DIFF
--- a/cf-template/kiln.template
+++ b/cf-template/kiln.template
@@ -380,8 +380,8 @@
         },
         "Tags": [
           {
-            "Key": "Name",
-            "Value": "Kiln Build Machine"
+            "Key": "kiln_component",
+            "Value": "container_build_machine"
           }
         ]
       }
@@ -391,7 +391,6 @@
       "DeletionPolicy": "Delete",
       "Properties": {
         "AccessControl": "Private",
-        "BucketName": "kiln-audit-trail",
         "Tags": [
           {
             "Key": "kiln_component",


### PR DESCRIPTION
as per docs, aws will create a unique name if
not one supplied. Rely on tagging to identify bucket
fixes #29